### PR TITLE
Iss exitcodes

### DIFF
--- a/snews_cs/snews_coinc.py
+++ b/snews_cs/snews_coinc.py
@@ -561,8 +561,8 @@ class CoincidenceDistributor:
             except KeyboardInterrupt:
                 print("Caught a keyboard interrupt.  Goodbye world!")
                 log.error(f"(2) Caught a keyboard interrupt. Exiting.\n")
-                self.exit_on_error = True
-                fatal_error = True
+                # exit with a zero status
+                sys.exit(0)
 
             # if there is a KafkaException, check if retriable
             except adc.errors.KafkaException as e:

--- a/snews_cs/snews_coinc.py
+++ b/snews_cs/snews_coinc.py
@@ -561,7 +561,8 @@ class CoincidenceDistributor:
             except KeyboardInterrupt:
                 print("Caught a keyboard interrupt.  Goodbye world!")
                 log.error(f"(2) Caught a keyboard interrupt. Exiting.\n")
-                # exit with a zero status
+                fatal_error = True
+                self.exit_on_error = True
                 sys.exit(0)
 
             # if there is a KafkaException, check if retriable


### PR DESCRIPTION
The keyboard interrupt is caught as an exception.  Handle that by allowing the program to exit.